### PR TITLE
Piksi V2 Install Script

### DIFF
--- a/piksi_rtk_gps/README.md
+++ b/piksi_rtk_gps/README.md
@@ -13,15 +13,14 @@ Based on the work of Daniel Eckert: [Original repo](https://bitbucket.org/Daniel
   * pandoc     `apt-get install pandoc`
   
 ### Installation
-The following code will automatically download the required version of libsbp, install it and add its python subfolder to your PYTHONPATH by adding a line in your .bashrc file.
+The following code will automatically download the required version of libsbp and install it in the default folder `/usr/local/lib/python2.7/dist-packages/sbp-VERSION_NUMBER-py2.7.egg/sbp/`.
 
 ```
 #from the repository folder
 chmod +x install/install_piksi.sh  #make sure the script is excutable
 ./install/install_piksi_v2.sh         # WARNING, this script will:
-                                      # 1. Add a line to your .bashrc to append the python subfolder of this repo to your $PYTHONPATH variable.
-                                      # 2. Create udev rule for Piksi
-                                      # 3. Add you to dialout, if you are not within this group
+                                      # 1. Create udev rule for Piksi
+                                      # 2. Add you to dialout, if you are not within this group
 ```
 ## Corrections Over Wifi
 It is possible to send/receive corrections over Wifi between multiple Piksi modules.

--- a/piksi_rtk_gps/install/install_piksi_v2.sh
+++ b/piksi_rtk_gps/install/install_piksi_v2.sh
@@ -5,11 +5,11 @@ echo " "
 echo "Installing SBP library for Piksi V2"
 
 GIT_REPO_LIBSBP=git@github.com:swift-nav/libsbp.git
-REPO_TAG=v1.2.1 #version you want to chechout before installing
+REPO_TAG=v1.2.1 #version you want to checkout before installing
 
 # Install libsbp in $HOME and compile it
-mkdir -p ~/software/piksi_sbp_lib_v2
-cd ~/software/piksi_sbp_lib_v2
+mkdir -p ~/piksi_sbp_lib_v2
+cd ~/piksi_sbp_lib_v2
 git clone $GIT_REPO_LIBSBP
 cd ./libsbp
 git checkout $REPO_TAG
@@ -26,10 +26,11 @@ sudo python setup.py install
 cd ..
 sudo make python
 
-echo "SBP Library Installed"
+# Remove temporary folder
+echo "Removing temporary folder"
+sudo rm -rf ~/piksi_sbp_lib_v2
 
-# Export PYTHONPATH and make sure it points to the python subdirectory of the repository
-sh -c 'echo "export PYTHONPATH=\${PYTHONPATH}:~/software/piksi_sbp_lib_v2/libsbp/python #add libsbp for RTK GPS Piksi V2 devices" >> ~/.bashrc'
+echo "SBP Library Installed"
 
 #---------------- Udev Rule ----------------
 echo " "


### PR DESCRIPTION
Use default folder for python modules and do not update `PYTHONPATH` in .bashrc anymore.

See issue [https://github.com/ethz-asl/mav_rtk_gps/issues/22](https://github.com/ethz-asl/mav_rtk_gps/issues/22)