### PR TITLE
Fix/installation scripts piksi multi

### DIFF
--- a/piksi_multi_rtk_gps/README.md
+++ b/piksi_multi_rtk_gps/README.md
@@ -15,11 +15,9 @@ ROS node to read SBP messages from an attached Piksi **Multi** RTK device.
 The following code will automatically download the required version of libsbp and install it in the default folder `/usr/local/lib/python2.7/dist-packages/sbp-2.2.1-py2.7.egg/sbp/`.
 
 ```
-#from the repository folder
-chmod +x install/install_piksi.sh  #make sure the script is excutable
-./install/install_piksi_multi.sh         # WARNING, this script will:
-                                         # 1. Create udev rule for Piksi
-                                         # 2. Add you to dialout, if you are not within this group
+# From the repository folder
+source install/install_piksi.sh     # This script will:
+                                                # 1. Request to add you to dialout, if you are not within this group
 ```
 
 ## Usage

--- a/piksi_multi_rtk_gps/README.md
+++ b/piksi_multi_rtk_gps/README.md
@@ -16,8 +16,7 @@ The following code will automatically download the required version of libsbp an
 
 ```
 # From the repository folder
-source install/install_piksi.sh     # This script will:
-                                                # 1. Request to add you to dialout, if you are not within this group
+source install/install_piksi_multi.sh
 ```
 
 ## Usage

--- a/piksi_multi_rtk_gps/install/install_piksi_multi.sh
+++ b/piksi_multi_rtk_gps/install/install_piksi_multi.sh
@@ -1,18 +1,40 @@
 #!/bin/bash
 
+GIT_REPO_LIBSBP=https://github.com/swift-nav/libsbp.git
+REPO_TAG=v2.2.1 #version you want to checkout before installing
+
+# Sort of reg express used to see if there is another verision on SBP library already installed
+# Adapted from https://stackoverflow.com/questions/6363441/check-if-a-file-exists-with-wildcard-in-shell-script
+SBP_PYTHON_DIRECTORY="/usr/local/lib/python2.7/dist-packages/sbp-*"
+
 #---------------- SBP ----------------
 echo " "
 echo "Installing SBP library for Piksi Multi."
 
-GIT_REPO_LIBSBP=https://github.com/swift-nav/libsbp.git
-REPO_TAG=v2.2.1 #version you want to checkout before installing
-
-# Install libsbp in $HOME and compile it
+# Download libsbp in $HOME and compile it
+STARTING_FOLDER=$(pwd)
 mkdir -p ~/piksi_sbp_lib_multi
 cd ~/piksi_sbp_lib_multi
 git clone $GIT_REPO_LIBSBP
 cd ./libsbp
 git checkout $REPO_TAG
+
+# Remove other Python libsbp, if any
+if ls $SBP_PYTHON_DIRECTORY 1> /dev/null 2>&1; then
+	echo " "
+    echo "Another version of libssbo is already installed in the system."
+    echo "Do you wish to remove it and install version $REPO_TAG ? [y or Y to accept]"
+	read remove_other_libspb
+
+	if [[ $remove_other_libspb == "Y" || $remove_other_libspb == "y" ]]; then
+		echo "Removing previous libsbp."
+		sudo rm -rf $SBP_PYTHON_DIRECTORY
+	else
+		echo "Installation procedure interrupted."
+		exit 1
+	fi
+
+fi
 
 # Install requirements.
 cd ./python
@@ -27,24 +49,28 @@ cd ..
 sudo make python
 
 # Remove temporary folder
+cd $STARTING_FOLDER
 echo "Removing temporary folder."
 sudo rm -rf ~/piksi_sbp_lib_multi
 
 echo "SBP Library Installed"
 
 #---------------- Dialout Group ----------------
-echo " "
-echo "Do you wish to add the current user ($USER) to 'dialout' group? [y or Y to accept]"
-read add_user_to_dialout
+if id -nG "$USER" | grep -qw dialout; then
+    echo "User $USER is already included in 'dialout' group."
+else
+    # $USER does not belong to dialout
+    echo " "
+	echo "Do you wish to add the current user ($USER) to 'dialout' group? [y or Y to accept]"
+	read add_user_to_dialout
 
-if [[ $add_user_to_dialout == "Y" || $add_user_to_dialout == "y" ]]; then
+	if [[ $add_user_to_dialout == "Y" || $add_user_to_dialout == "y" ]]; then
+	    echo "Adding user $USER to 'dialout' group."
+	    sudo adduser $(whoami) dialout
+	    echo "Please logout and back in for the new group to take effect."
+	fi
 
-  if id -nG "$USER" | grep -qw dialout; then
-    # user already belongs to dialout
-    echo "User $USER was already included in 'dialout' group."
-  else
-    echo "Adding user $USER to 'dialout' group."
-    sudo adduser $(whoami) dialout
-    echo "Please logout and back in for the new group to take effect."
-  fi
 fi
+
+echo " "
+echo "Installation completed."

--- a/piksi_rtk_gps/README.md
+++ b/piksi_rtk_gps/README.md
@@ -1,6 +1,10 @@
 piksi_rtk_gps
 ======
-ROS node to read SBP messages from an attached Piksi **V2** RTK device.
+**WARNING: this ROS driver for Piksi V2.3 is NOT longer supported!**
+
+**If you have a Piksi Multi, please check the lates ROS driver: [piksi_multi_rtk_gps](https://github.com/ethz-asl/mav_rtk_gps/tree/master/piksi_multi_rtk_gps)**
+
+ROS node to read SBP messages from an attached Piksi **V2.3** RTK device.
 
 Based on the work of Daniel Eckert: [Original repo](https://bitbucket.org/Daniel-Eckert/mav_localization).
 
@@ -12,7 +16,7 @@ Based on the work of Daniel Eckert: [Original repo](https://bitbucket.org/Daniel
   * pandoc     `sudo apt-get install pandoc`
 
 ### Installation
-**WARNING: install __ONLY ONE__ version of SBP library, depending of which Hardware version you are using. This page cointains the driver for [Piksi V2](http://docs.swiftnav.com/pdfs/piksi_datasheet_v2.3.1.pdf). If you are using [Piksi Multi](https://www.swiftnav.com/piksi-multi) please check its driver version: [piksi_multi_rtk_gps](https://github.com/ethz-asl/mav_rtk_gps/tree/master/piksi_multi_rtk_gps) please check its driver version: [piksi_multi_rtk_gps](https://github.com/ethz-asl/mav_rtk_gps/tree/master/piksi_multi_rtk_gps).**
+**WARNING: install __ONLY ONE__ version of SBP library, depending of which Hardware version you are using. This page cointains the driver for [Piksi V2.3](http://docs.swiftnav.com/pdfs/piksi_datasheet_v2.3.1.pdf). If you are using [Piksi Multi](https://www.swiftnav.com/piksi-multi) please check its driver version: [piksi_multi_rtk_gps](https://github.com/ethz-asl/mav_rtk_gps/tree/master/piksi_multi_rtk_gps) please check its driver version: [piksi_multi_rtk_gps](https://github.com/ethz-asl/mav_rtk_gps/tree/master/piksi_multi_rtk_gps).**
 
 The following code will automatically download the required version of libsbp and install it in the default folder `/usr/local/lib/python2.7/dist-packages/sbp-1.2.1-py2.7.egg/sbp/`.
 


### PR DESCRIPTION
- Piksi Multi installation script will remove the old libsbp python library if present, before downloading the one specified at the beginning of the file.
- Update readme files of Piksi Multi and Piksi V2.3.